### PR TITLE
Add UNUserNotificationCenterProtocol to abstract processes such as adding notifications

### DIFF
--- a/Sources/LocalNotificationEditor/Internal/LocalNotificationEditor.swift
+++ b/Sources/LocalNotificationEditor/Internal/LocalNotificationEditor.swift
@@ -34,7 +34,7 @@ struct LocalNotificationEditor: View {
         !identifier.isEmpty && (!title.isEmpty || !subtitle.isEmpty || !bodyString.isEmpty)
     }
 
-    let userNotificationCenter: UNUserNotificationCenter
+    let userNotificationCenter: any UNUserNotificationCenterProtocol
     let mode: Mode
     let onSave: () -> Void
 
@@ -61,7 +61,7 @@ struct LocalNotificationEditor: View {
     }
 
     init(
-        userNotificationCenter: UNUserNotificationCenter,
+        userNotificationCenter: some UNUserNotificationCenterProtocol,
         mode: Mode,
         onSave: @escaping () -> Void
     ) {
@@ -236,7 +236,7 @@ struct LocalNotificationEditor: View {
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Save") {
-                        saveButtonTapped()
+                        Task { try await saveButtonTapped() }
                     }
                     .disabled(!isSaveButtonEnabled)
                 }
@@ -342,7 +342,7 @@ struct LocalNotificationEditor: View {
         }
     }
 
-    private func saveButtonTapped() {
+    private func saveButtonTapped() async throws {
         let request = UNNotificationRequest(
             identifier: identifier,
             content: createNotificationContent(),
@@ -350,10 +350,10 @@ struct LocalNotificationEditor: View {
         )
         switch mode {
         case .add:
-            userNotificationCenter.add(request)
+            try await userNotificationCenter.add(request)
         case .edit:
             userNotificationCenter.removePendingNotificationRequests(withIdentifiers: [request.identifier])
-            userNotificationCenter.add(request)
+            try await userNotificationCenter.add(request)
         }
         dismiss()
         onSave()
@@ -391,7 +391,7 @@ struct LocalNotificationEditor: View {
 
 #Preview {
     LocalNotificationEditor(
-        userNotificationCenter: .current(),
+        userNotificationCenter: UNUserNotificationCenter.current(),
         mode: .add
     ) {}
 }

--- a/Sources/LocalNotificationEditor/LocalNotificationList.swift
+++ b/Sources/LocalNotificationEditor/LocalNotificationList.swift
@@ -7,9 +7,9 @@ public struct LocalNotificationList: View {
     @State var isAddNotificationEditorPresented = false
     @State var isDeleteAllAlertPresented = false
 
-    let userNotificationCenter: UNUserNotificationCenter
+    let userNotificationCenter: any UNUserNotificationCenterProtocol
 
-    public init(userNotificationCenter: UNUserNotificationCenter) {
+    public init(userNotificationCenter: some UNUserNotificationCenterProtocol) {
         self.userNotificationCenter = userNotificationCenter
     }
 
@@ -125,6 +125,6 @@ public struct LocalNotificationList: View {
     }
 
     private func update() async {
-        notificationRequests = await UNUserNotificationCenter.current().pendingNotificationRequests()
+        notificationRequests = await userNotificationCenter.pendingNotificationRequests()
     }
 }

--- a/Sources/LocalNotificationEditor/NotificationCenterProtocol.swift
+++ b/Sources/LocalNotificationEditor/NotificationCenterProtocol.swift
@@ -1,0 +1,11 @@
+import Foundation
+import UserNotifications
+
+public protocol UNUserNotificationCenterProtocol {
+    func add(_ request: UNNotificationRequest) async throws
+    func removeAllPendingNotificationRequests()
+    func pendingNotificationRequests() async -> [UNNotificationRequest]
+    func removePendingNotificationRequests(withIdentifiers: [String])
+}
+
+extension UNUserNotificationCenter: UNUserNotificationCenterProtocol {}


### PR DESCRIPTION
Add UNUserNotificationCenterProtocol to abstract processes such as adding notifications.
This made it possible to add some processing when adding a Notification.